### PR TITLE
圧縮率設定機能の追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,28 +29,45 @@
             <label for="inputFile" class="form-label">Select GLB/GLTF File</label>
             <input type="file" name="file" class="form-control" id="inputFile" required>
           </div>
+
           <div class="mb-3 text-start">
             <label for="ratio" class="form-label">LOD Ratio</label>
             <input type="number" step="0.01" name="ratio" class="form-control" id="ratio" value="0.08" required>
           </div>
+
           <div class="mb-3 text-start">
             <label for="error" class="form-label">LOD Error</label>
             <input type="number" step="0.01" name="error" class="form-control" id="error" value="1" required>
           </div>
+
+          <div class="mb-3 text-start">
+            <label for="compressionRate" class="form-label">Texture Compression Rate</label>
+            <input
+              type="range"
+              class="form-range"
+              id="compressionRate"
+              name="compressionRate"
+              min="0"
+              max="1"
+              step="0.01"
+              value="0.1"
+              oninput="this.nextElementSibling.value = this.value"
+              required
+            >
+            <output>0.1</output>
+          </div>
+
           <button type="submit" class="btn btn-custom">Upload and Generate LOD</button>
         </form>
       </div>
     </div>
 
     <div class="row mt-4">
-      <div class="col-md-6">
-        <div id="scene-container" style="width: 100%; height: 400px;"></div>
-      </div>
-      <div class="col-md-6">
-        <div id="model-viewer" style="width: 100%; height: 400px;">
-        </div>
-      </div>
+      <div id="scene-container" style="width: 100%; height: 400px;"></div>
     </div>
+  </div>
+
+  <div id="model-viewer" style="width: 100%; height: 400px;">
   </div>
 </body>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ const createStaticModelViewer = async (model: THREE.Group): Promise<string | und
   const scene = new THREE.Scene();
 
   const staticViewerContainer = document.getElementById('model-viewer') as HTMLDivElement;
+  staticViewerContainer.hidden = false;
 
   const renderer = new THREE.WebGLRenderer();
   staticViewerContainer.appendChild(renderer.domElement);
@@ -48,6 +49,7 @@ const createStaticModelViewer = async (model: THREE.Group): Promise<string | und
 
   // レンダリングされた画像をBase64エンコードされた文字列として取得
   const imageDataUrl = renderer.domElement.toDataURL('image/png');
+  staticViewerContainer.hidden = true;
   return await sendImageDataToServer(imageDataUrl);
 }
 

--- a/src/sceneSetup.ts
+++ b/src/sceneSetup.ts
@@ -40,7 +40,8 @@ export const setupScene = (container: HTMLElement) => {
 
   setupSceneLighting(scene);
 
-  camera.position.z = 5;
+  camera.position.y = 0.5;
+  camera.position.z = 2.5;
 };
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
         changeOrigin: true,
       }
     }
-  }
+  },
+  build: {
+    chunkSizeWarningLimit: 600,
+  },
 })


### PR DESCRIPTION
- フォームにテクスチャ圧縮率の入力フィールドを追加
  - Bootstrap5の`<input type="range">`を使用
  - 圧縮率の値を表示するための`<output>`要素を追加
- Sinatraアプリケーションで圧縮率のパラメータを受け取り、`glb-texture-converter`コマンドに渡す処理を追加
- モデルビューアの表示を改善
  - モデル表示中のUIを調整
- Viteの設定を更新し、ビルド時のチャンクサイズ警告の制限を調整